### PR TITLE
Add SSE transport option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ The script will:
    ```bash
    ES_CLOUD_ID=your_cloud_id ES_API_KEY=your_api_key python es_mcp_server.py
    ```
+   To use server-sent events instead of stdio, pass `--transport sse` or set `MCP_TRANSPORT=sse`:
+   ```bash
+   ES_CLOUD_ID=your_cloud_id ES_API_KEY=your_api_key python es_mcp_server.py --transport sse
+   ```
 
 2. In Claude, use the `access_mcp_resource` tool to access the resources:
 

--- a/es_mcp_server.py
+++ b/es_mcp_server.py
@@ -322,4 +322,14 @@ async def list_indices_resource() -> str:
 
 
 if __name__ == "__main__":
-    mcp.run(transport="stdio")
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the Elasticsearch MCP server")
+    parser.add_argument(
+        "--transport",
+        default=os.environ.get("MCP_TRANSPORT", "stdio"),
+        help="Transport to use for FastMCP (e.g. 'stdio' or 'sse')",
+    )
+    args = parser.parse_args()
+
+    mcp.run(transport=args.transport)


### PR DESCRIPTION
## Summary
- add a `--transport` CLI option to choose between `stdio` and SSE transports
- document running with SSE in README

## Testing
- `python -m py_compile es_mcp_server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405c83529883298e8884af421e55f0